### PR TITLE
Update Windows VM size to Standard_D8s_v6

### DIFF
--- a/infra/nestedhyperv.bicep
+++ b/infra/nestedhyperv.bicep
@@ -7,7 +7,7 @@ param environmentName string
 param windowsOSVersion string = '2025-Datacenter'
 
 @description('Size for Windows hyper-vhost VM')
-param winVmSize string = 'Standard_D8s_v5'
+param winVmSize string = 'Standard_D8s_v6'
 
 @description('Username for Windows hyperv-host VM')
 param winVmUser string


### PR DESCRIPTION
v6 is more commonly available in regions than v5 version